### PR TITLE
Updated README.md for disambiguation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ docker-statsd-influxdb [![wercker status](https://app.wercker.com/status/eb09242
 
 Out-of-the-box StatsD + InfluxDB backend image for Docker
 
+## Introduction
+
+This Docker container is based on [`node:slim`](https://registry.hub.docker.com/u/library/node/) and runs a StatsD instance with backend support for InfluxDB. All settings for the StatsD instance to connect with InfluxDB can be provided using environmental variables.
 
 ## Running
 


### PR DESCRIPTION
Adding some extra information to the README because the title of the container lead me to believe that it contained InfluxDB as well as StatsD, it wasn't until I spent time trying to figure out why InfluxDB wasn't there that I figured out that it's only the InfluxDB backend support was installed.
