### PR TITLE
Adding InfluxDB 0.9 Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-# DOCKER-VERSION 1.3
+# DOCKER-VERSION 1.6
 # AUTHOR: Minku Lee <minku@sha.kr>
 # DESCRIPTION: Out-of-the-box StatsD + InfluxDB backend image for Docker
 
-FROM node:0.10.33-slim
+FROM node:0.12.7-slim
 
+RUN apt-get update && apt-get install -y git
 RUN git clone https://github.com/etsy/statsd.git
-RUN cd /statsd && npm install statsd-influxdb-backend
+RUN cd /statsd && npm install generic-pool statsd-influxdb-backend
 
 ADD config.js /statsd/config.js
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# DOCKER-VERSION 1.6
+# DOCKER-VERSION 1.10
 # AUTHOR: Minku Lee <minku@sha.kr>
 # DESCRIPTION: Out-of-the-box StatsD + InfluxDB backend image for Docker
 
-FROM node:0.12.7-slim
+FROM node:4.1.1-slim
 
 RUN apt-get update && apt-get install -y git
 RUN git clone https://github.com/etsy/statsd.git

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Out-of-the-box StatsD + InfluxDB backend container for Docker
 
 This Docker container is based on [`node:slim`](https://registry.hub.docker.com/u/library/node/) and runs a [`StatsD`](https://github.com/etsy/statsd/) network daemon with native backend support for [`InfluxDB`](https://github.com/influxdb/influxdb/tree/master) using the [`statsd-influxdb-backend`](https://github.com/bernd/statsd-influxdb-backend) node.js package. All settings for the [`StatsD`](https://github.com/etsy/statsd/) daemon to connect with [`InfluxDB`](https://github.com/influxdb/influxdb/tree/master) can be provided using environmental variables.
 
-The current version [`statsd-influxdb-backend v0.6.0`](https://github.com/bernd/statsd-influxdb-backend) included in this container supports [`InfluxDB`](https://github.com/influxdb/influxdb/tree/master) versions `v0.8` and `v0.9`.
+The node package [`statsd-influxdb-backend`](https://github.com/bernd/statsd-influxdb-backend) `v0.6.0` included in this container supports [`InfluxDB`](https://github.com/influxdb/influxdb/tree/master) versions `v0.8` and `v0.9`.
 
 ## Considerations
 
-- The default version of [`InfluxDB`](https://github.com/influxdb/influxdb/tree/master) for this container is `v0.8`, use the `INFLUXDB_VERSION` environment variable to specify [`InfluxDB v0.9`](https://github.com/influxdb/influxdb/tree/master)
-- Ensure that any programs that you are using with the [`StatsD`](https://github.com/etsy/statsd/)/[`InfluxDB`](https://github.com/influxdb/influxdb/tree/master) stack support `v0.9`, support in the community is still being finalised
-- [`InfluxDB v0.9`](https://github.com/influxdb/influxdb/tree/master) currently has no upgrade tool from `v0.8`, so you will need to start with a fresh database
+- The default version of [`InfluxDB`](https://github.com/influxdb/influxdb/tree/master) for this container is `v0.8`, use the `INFLUXDB_VERSION` environment variable to specify `v0.9`
+- [`InfluxDB`](https://github.com/influxdb/influxdb/tree/master) `v0.9` currently has no upgrade tool from `v0.8`, you will need to start with a fresh database
+- Ensure that any programs that you are using with the [`StatsD`](https://github.com/etsy/statsd/)/[`InfluxDB`](https://github.com/influxdb/influxdb/tree/master) stack support `v0.9`, support in the community is still being finalised and you may lose functionality by moving to the new version
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 docker-statsd-influxdb [![wercker status](https://app.wercker.com/status/eb092421caa7bd703ac332444f7e978b/s "wercker status")](https://app.wercker.com/project/bykey/eb092421caa7bd703ac332444f7e978b)
 ======================
 
-Out-of-the-box StatsD + InfluxDB backend image for Docker
+Out-of-the-box StatsD + InfluxDB backend container for Docker
 
+## Introduction
+
+This Docker container is based on [`node:slim`](https://registry.hub.docker.com/u/library/node/) and runs a [`StatsD`](https://github.com/etsy/statsd/) network daemon with native backend support for [`InfluxDB`](https://github.com/influxdb/influxdb/tree/master) using the [`statsd-influxdb-backend`](https://github.com/bernd/statsd-influxdb-backend) node.js package. All settings for the [`StatsD`](https://github.com/etsy/statsd/) daemon to connect with [`InfluxDB`](https://github.com/influxdb/influxdb/tree/master) can be provided using environmental variables.
+
+The current version [`statsd-influxdb-backend v0.6.0`](https://github.com/bernd/statsd-influxdb-backend) included in this container supports [`InfluxDB`](https://github.com/influxdb/influxdb/tree/master) versions `v0.8` and `v0.9`.
+
+## Considerations
+
+- The default version of [`InfluxDB`](https://github.com/influxdb/influxdb/tree/master) for this container is `v0.8`, use the `INFLUXDB_VERSION` environment variable to specify [`InfluxDB v0.9`](https://github.com/influxdb/influxdb/tree/master)
+- Ensure that any programs that you are using with the [`StatsD`](https://github.com/etsy/statsd/)/[`InfluxDB`](https://github.com/influxdb/influxdb/tree/master) stack support `v0.9`, support in the community is still being finalised
+- [`InfluxDB v0.9`](https://github.com/influxdb/influxdb/tree/master) currently has no upgrade tool from `v0.8`, so you will need to start with a fresh database
 
 ## Running
 
@@ -10,13 +21,16 @@ Example command to run this image:
 
     docker run -p 8125:8125/udp -e "INFLUXDB_HOST=localhost" -e "INFLUXDB_DATABASE=site_dev" -e "INFLUXDB_USERNAME=username" -e "INFLUXDB_PASSWORD=password" -e "STATSD_DEBUG=true" shakr/statsd-influxdb
 
-Following environment varaiables can be used:
+Following environment variables can be used:
 
 - `INFLUXDB_HOST` or `INFLUXDB_MASTER_SERVICE_HOST` (default: localhost)
 - `INFLUXDB_PORT` or `INFLUXDB_MASTER_SERVICE_PORT` (default: 8086)
+- `INFLUXDB_VERSION` (default: 0.8, latest: 0.9)
+- `INFLUXDB_SSL` (default: false)
 - `INFLUXDB_DATABASE` (default: site_dev)
 - `INFLUXDB_USERNAME` (default: root)
 - `INFLUXDB_PASSWORD` (default: root)
+
 - `STATSD_PORT` (default: 8125)
 - `STATSD_DEBUG` (default: false)
 - `STATSD_ENABLE_FLUSH` (default: true)

--- a/config.js
+++ b/config.js
@@ -20,6 +20,8 @@
     influxdb: {
       host: host,
       port: port,
+      version: process.env.INFLUXDB_VERSION || "0.8",
+      ssl: process.env.INFLUXDB_SSL || "false",
       database: process.env.INFLUXDB_DATABASE || "site_dev",
       username: process.env.INFLUXDB_USERNAME || "root",
       password: process.env.INFLUXDB_PASSWORD || "root",

--- a/config.js
+++ b/config.js
@@ -21,7 +21,7 @@
       host: host,
       port: port,
       version: process.env.INFLUXDB_VERSION || "0.8",
-      ssl: process.env.INFLUXDB_SSL || "false",
+      ssl: (process.env.INFLUXDB_SSL || "false").toLowerCase() === "true",
       database: process.env.INFLUXDB_DATABASE || "site_dev",
       username: process.env.INFLUXDB_USERNAME || "root",
       password: process.env.INFLUXDB_PASSWORD || "root",


### PR DESCRIPTION
I moved to InfluxDB version 0.9 last week and updated this container to work with the new version. I've left the default version as InfluxDB 0.8 for the meantime, as applications like Grafana are still finalising 0.9 support. The plugin for StatsD does have full support for 0.9 now, so I thought it was worth updating this package. The changes I made for this commit are:
- Updated to `node:0.12.7-slim` container
- Updated to npm plugin `statsd-influxdb-backend v0.60` for `InfluxDB v0.9` support
- Added generic-pool plugin for node as it was missing in `node:0.12.7-slim`
- Added git install to `Dockerfile` as it was not inbuilt in `node:0.12.7` slim
- Added evironmental variables to config.js for `InfluxDB v0.9` support
- Updated `README.md` with additional information related to `InfluxDB` versions and new environment variables

I've tested this container to collect stats and visualise the data with Grafana 2.0.2 using the preliminary InfluxDB v0.9 support. Everything is working correctly.

Do you think it might be worthwhile adding a changelog and git tags to track the version changes? It's pretty simple container so it might not be worthwhile.
